### PR TITLE
Make it easier to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ _NOTE_: You may need to configure Powershell to allow this script to be run. A s
 ## Using
 Just run the script with Powershell on the slave!
 
+If you want to use Jenkins to update your Jenkins slaves (well, that sounds crazy), you need to make sure that the slave is restarted after the Job is finished. As http://wiki.jenkins-ci.org/display/JENKINS/Spawning+processes+from+build say, this is complicated by the fact that Jenkins tries to be helpful and kills processes lingering after the Job is finished. This build step worked for me:
+
+    copy *.ps1 %BASE%
+    set BUILD_ID=dontKillMe
+    start powershell -NoProfile -ExecutionPolicy Bypass %base%\jenkins-slave-updater.ps1 -Sleep 30
+
 ## WTF is going on?
 This script stops the running "Jenkins Slave" service, pulls down the latest `slave.jar` from the master server, and restarts the service.
 

--- a/jenkins-slave-updater.ps1
+++ b/jenkins-slave-updater.ps1
@@ -1,6 +1,12 @@
 # version 0.2.0
 # for more info, see: https://github.com/versionone/jenkins-slave-updater
 
+param (
+     [int]$sleep = 0
+)
+
+Start-Sleep -s $sleep
+
 # Get Service name & master Server from Agent XML
 [xml]$data = Get-Content "$PSScriptRoot\jenkins-slave.xml"
 $args = $data.service.arguments

--- a/jenkins-slave-updater.ps1
+++ b/jenkins-slave-updater.ps1
@@ -1,13 +1,24 @@
 # version 0.2.0
 # for more info, see: https://github.com/versionone/jenkins-slave-updater
 
+# Get Service name & master Server from Agent XML
+[xml]$data = Get-Content "jenkins-slave.xml"
+$args = $data.service.arguments
+$masterUrlMatch = [regex]
+if ($args -match "-jnlpUrl (http[^ ]*)/computer/[^ /]*/slave-agent.jnlp ") {
+	$base = $matches[1]
+} else {
+	$base = "http://ci-server.corp.versionone.net/"
+}
+$servicename = $data.service.id
+
 echo "=== Stopping Jenkins Slave ==="
-$jenkins = get-service -displayname "Jenkins Slave"
+$jenkins = get-service -name $servicename
 $jenkins.Stop()
 $jenkins.WaitForStatus("Stopped")
 
-echo "=== Getting new slave.jar from Master server ==="
-Invoke-WebRequest "http://ci-server.corp.versionone.net/jnlpJars/slave.jar" -OutFile "slave.jar"
+echo "=== Getting new slave.jar from Master server $base ==="
+Invoke-WebRequest "$base/jnlpJars/slave.jar" -OutFile "slave.jar"
 
 echo "=== Starting Jenkins Slave ==="
 $jenkins.Start()

--- a/jenkins-slave-updater.ps1
+++ b/jenkins-slave-updater.ps1
@@ -7,7 +7,7 @@ $jenkins.Stop()
 $jenkins.WaitForStatus("Stopped")
 
 echo "=== Getting new slave.jar from Master server ==="
-invoke-command -scriptblock { curl -O "http://ci-server.corp.versionone.net/jnlpJars/slave.jar" }
+Invoke-WebRequest "http://ci-server.corp.versionone.net/jnlpJars/slave.jar" -OutFile "slave.jar"
 
 echo "=== Starting Jenkins Slave ==="
 $jenkins.Start()

--- a/jenkins-slave-updater.ps1
+++ b/jenkins-slave-updater.ps1
@@ -7,8 +7,10 @@ param (
 
 Start-Sleep -s $sleep
 
+$dir = Split-Path $script:MyInvocation.MyCommand.Path
+
 # Get Service name & master Server from Agent XML
-[xml]$data = Get-Content "$PSScriptRoot\jenkins-slave.xml"
+[xml]$data = Get-Content "$dir\jenkins-slave.xml"
 $args = $data.service.arguments
 $masterUrlMatch = [regex]
 if ($args -match "-jnlpUrl (http[^ ]*)/computer/[^ /]*/slave-agent.jnlp ") {
@@ -24,7 +26,7 @@ $jenkins.Stop()
 $jenkins.WaitForStatus("Stopped")
 
 echo "=== Getting new slave.jar from Master server $base ==="
-Invoke-WebRequest "$base/jnlpJars/slave.jar" -OutFile "$PSScriptRoot\slave.jar"
+Invoke-WebRequest "$base/jnlpJars/slave.jar" -OutFile "$dir\slave.jar"
 
 echo "=== Starting Jenkins Slave ==="
 $jenkins.Start()

--- a/jenkins-slave-updater.ps1
+++ b/jenkins-slave-updater.ps1
@@ -2,7 +2,7 @@
 # for more info, see: https://github.com/versionone/jenkins-slave-updater
 
 # Get Service name & master Server from Agent XML
-[xml]$data = Get-Content "jenkins-slave.xml"
+[xml]$data = Get-Content "$PSScriptRoot\jenkins-slave.xml"
 $args = $data.service.arguments
 $masterUrlMatch = [regex]
 if ($args -match "-jnlpUrl (http[^ ]*)/computer/[^ /]*/slave-agent.jnlp ") {
@@ -18,7 +18,7 @@ $jenkins.Stop()
 $jenkins.WaitForStatus("Stopped")
 
 echo "=== Getting new slave.jar from Master server $base ==="
-Invoke-WebRequest "$base/jnlpJars/slave.jar" -OutFile "slave.jar"
+Invoke-WebRequest "$base/jnlpJars/slave.jar" -OutFile "$PSScriptRoot\slave.jar"
 
 echo "=== Starting Jenkins Slave ==="
 $jenkins.Start()


### PR DESCRIPTION
These are 2 changes which make the script easier to use:
1. Use PowerShell-builtin Invoke-WebRequest, so curl isn't needed
2. Fetches the remote URL from the jenkins-slave.xml, so you don't need to edit the script at all ;)
